### PR TITLE
style: fix gallery grid for 2xl screens

### DIFF
--- a/components/GalleryFull.tsx
+++ b/components/GalleryFull.tsx
@@ -126,7 +126,7 @@ const GalleryFull = ({
 
   return (
     <>
-      <div className="grid grid-cols-3 gap-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-5 3xl:grid-cols-6">
+      <div className="grid grid-cols-3 gap-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-5">
         {items.map((i, index) => (
           <InscriptionCard key={i?.id ?? index} inscription={i} light />
         ))}


### PR DESCRIPTION
Improvement suggestion, because we fetch 20 inscriptions per page, seeing 6 inscriptions per row doesn't fit nicely.

Here a preview with the fix.
Showing 4*5 inscription (instead of 3*6+2)

![Screenshot 2023-07-17 at 17-36-32 Ordinals — Hiro](https://github.com/hirosystems/ordinals-explorer/assets/911307/31f228a1-9226-475c-b640-8582f6821689)
