### PR TITLE
fix: update transfer check

### DIFF
--- a/components/inscriptions/InscriptionDetails.tsx
+++ b/components/inscriptions/InscriptionDetails.tsx
@@ -52,8 +52,7 @@ const InscriptionDetails = (params: { iid: string }) => {
     );
   // todo: reusable error component (maybe including loading)
 
-  // todo: add better check (could be the same if transferred in same block?)
-  const wasTransferred = data.timestamp !== data.genesis_timestamp;
+  const wasTransferred = data.tx_id !== data.genesis_tx_id;
 
   return (
     <TooltipProvider delayDuration={0}>


### PR DESCRIPTION
- fixes check reported by @rafaelcr -- new check uses tx_id and genesis_tx_id, (instead of timestamp which is equivalent to using block height)

> It looks like the Explorer may not be reporting transfers correctly here: https://ordinals.hiro.so/inscription/53957f47697096cef4ad24dae6357b3d7ffe1e3eb9216ce0bb01d6b6a2c8cf4ai0
If you look at [the transfers API response](https://api.hiro.so/ordinals/inscriptions/53957f47697096cef4ad24dae6357b3d7ffe1e3eb9216ce0bb01d6b6a2c8cf4ai0/transfers) for this inscription, it does have 1 transfer. Perhaps may be due to the fact that the transfer happened in the same block where it was inscribed. (edited)