### PR TITLE
fix: prevent xsleaks

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,7 +17,10 @@ const nextConfig = {
     return [
       {
         source: "/:path*",
-        headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "Cross-Origin-Opener-Policy", value: "same-origin" }
+        ],
       },
     ];
   },


### PR DESCRIPTION
Unless another domain is authorized to open a window of `ordinals.hiro.so`,`Cross-Origin-Opener-Policy` should be set to `same-origin` to prevent xsleaks

ref https://xsleaks.dev/docs/defenses/opt-in/coop/

