### PR TITLE
Update Footer.tsx

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -23,13 +23,13 @@ const Footer = () => {
               {/* todo: link chainhooks */}
               <p className="text-sm text-neutral-0">
                 This Ordinals Explorer is using the{" "}
-                <a className="underline" href="https://docs.hiro.so/ordinals">
+                <a className="underline" href="https://www.hiro.so/ordinals-api">
                   Hiro Ordinals API
                 </a>{" "}
                 powered by{" "}
                 <a
                   className="underline"
-                  href="https://github.com/hirosystems/ordhook"
+                  href="https://www.hiro.so/ordhook"
                 >
                   Ordhook
                 </a>


### PR DESCRIPTION
This PR swaps out links in the Explorer footer.

In particular, it changes the links for the Ordinals API and Ordhook (that previously linked to a 404 docs page and a GitHub repo respectively) for links to our product pages on the Hiro website.